### PR TITLE
Fix 'group with id "AnalyzeMenu" isn't registered'

### DIFF
--- a/intellij-code-cleaner/src/main/resources/META-INF/plugin.xml
+++ b/intellij-code-cleaner/src/main/resources/META-INF/plugin.xml
@@ -21,7 +21,7 @@
                 class="net.ntworld.intellijCodeCleaner.AnalyzeMenuAction"
                 text="Analyze Code Smells and Duplications..."
         >
-            <add-to-group group-id="AnalyzeMenu" anchor="last"/>
+            <add-to-group group-id="CodeMenu" anchor="last"/>
         </action>
     </actions>
 


### PR DESCRIPTION
Fixes anoying error popping out: #10 #12

I don't know where it was supposed to go, so I put it in CodeMenu since it seemed most appropriate.